### PR TITLE
Change method to get users_folder

### DIFF
--- a/CDIR/CDIR.cpp
+++ b/CDIR/CDIR.cpp
@@ -949,19 +949,12 @@ int main(int argc, char **argv)
 	}
 
 	sprintf(foldername, "%s_%s", computername, timestamp);
-	if (argc > 1) {
-		strncpy(outdir, argv[1], MAX_PATH + 1);
-	}else if (config->isSet("Output")) {
-		strncpy(outdir, (CASTVAL(string, config->getValue("Output"))).c_str(), MAX_PATH + 1);
-	}
-	else {
-		outdir[0] = '\0';
-	}
-	if (strlen(outdir) != 0 && !SetCurrentDirectory(outdir)) {
-		cerr << msg("保存先: ", "Output Directory: ") << outdir << endl;
-		cerr << msg("対応していない保存先です", "unsupported destination") << endl;
-		// _perror("SetCurrentDirectory:");
-		__exit(EXIT_FAILURE);
+	if (config->isSet("Output")) {
+		if (!SetCurrentDirectory((CASTVAL(string, config->getValue("Output"))).c_str())) {
+			cerr << msg("対応していない保存先です", "unsupported destination") << endl;
+			// _perror("SetCurrentDirectory:");
+			__exit(EXIT_FAILURE);
+		}
 	}
 
 	mkdir(foldername);

--- a/CDIR/CDIR.cpp
+++ b/CDIR/CDIR.cpp
@@ -829,7 +829,7 @@ int main(int argc, char **argv)
 
 	// chack proces name
 	procname = basename(string(argv[0]));
-	cout << msg("CDIR Collector v1.2.1 - 初動対応用データ収集ツール", "CDIR Collector v1.2.1 - Data Acquisition Tool for First Response") << endl;
+	cout << msg("CDIR Collector v1.2.1z - 初動対応用データ収集ツール", "CDIR Collector v1.2.1z - Data Acquisition Tool for First Response") << endl;
 	cout << msg("Cyber Defense Institute, Inc.\n", "Cyber Defense Institute, Inc.\n") << endl;
 
 	// getting config

--- a/CDIR/CDIR.cpp
+++ b/CDIR/CDIR.cpp
@@ -231,7 +231,7 @@ int StealthGetFile(char *filepath, char *outpath, ostringstream *osslog = NULL, 
 	FileInfo_t *file;
 	if ((file = StealthOpenFile(filepath)) == NULL) {
 		fprintf(stderr, "could not open file: %s\n", filepath);
-		__exit(EXIT_FAILURE);
+		return -1;
 	};
 
 	ULONGLONG filesize = (ULONGLONG)file->data->GetDataSize();
@@ -831,7 +831,7 @@ int main(int argc, char **argv)
 
 	// chack proces name
 	procname = basename(string(argv[0]));
-	cout << msg("CDIR Collector v1.2.1z - 初動対応用データ収集ツール", "CDIR Collector v1.2.1z - Data Acquisition Tool for First Response") << endl;
+	cout << msg("CDIR Collector v1.2.1_20171226 - 初動対応用データ収集ツール", "CDIR Collector v1.2.1_20171226 - Data Acquisition Tool for First Response") << endl;
 	cout << msg("Cyber Defense Institute, Inc.\n", "Cyber Defense Institute, Inc.\n") << endl;
 
 	// set curdir -> exedir

--- a/CDIR/CDIR.cpp
+++ b/CDIR/CDIR.cpp
@@ -841,6 +841,11 @@ int main(int argc, char **argv)
 	}
 	PathRemoveFileSpec(exedir);
 
+	if (!SetCurrentDirectory(exedir)) {
+		_perror("SetCurrentDirectory:");
+		__exit(EXIT_FAILURE);
+	}
+
 	// getting config
 	string confnames[2] = { std::string(exedir) + "\\cdir.ini", std::string(exedir) + "\\cdir.conf"};
 	for (string confname : confnames) {

--- a/CDIR/CDIR.cpp
+++ b/CDIR/CDIR.cpp
@@ -840,13 +840,9 @@ int main(int argc, char **argv)
 		__exit(EXIT_FAILURE);
 	}
 	PathRemoveFileSpec(exedir);
-	if (!SetCurrentDirectory(exedir)) {
-		_perror("SetCurrentDirectory:");
-		__exit(EXIT_FAILURE);
-	}
 
 	// getting config
-	string confnames[2] = {"cdir.ini", "cdir.conf"};
+	string confnames[2] = { std::string(exedir) + "\\cdir.ini", std::string(exedir) + "\\cdir.conf"};
 	for (string confname : confnames) {
 		config = new ConfigParser(confname);
 		if (config && config->isOpened()) {

--- a/CDIR/CDIR.cpp
+++ b/CDIR/CDIR.cpp
@@ -268,9 +268,9 @@ int StealthGetFile(char *filepath, char *outpath, ostringstream *osslog = NULL, 
 	}
 
 	char journalpath[MAX_PATH + 1];
-	sprintf(journalpath, "%s\\$Extend\\$UsnJrnl:$J", osvolume);
+	sprintf(journalpath, "\\$Extend\\$UsnJrnl:$J");
 
-	if (!WriteWrapper::isLocal() && !(SparseSkip && strcmp(filepath, journalpath) == 0)) { // if using WebDAV and reading file except UsnJrnl
+	if (!WriteWrapper::isLocal() && !(SparseSkip && strlen(filepath) > 3 && strcmp(&(filepath[2]), journalpath) == 0)) { // if using WebDAV and reading file except UsnJrnl
 		if (wfile.sendheader()) {
 			fprintf(stderr, "failed to send header.\n");
 			return -1;
@@ -282,7 +282,7 @@ int StealthGetFile(char *filepath, char *outpath, ostringstream *osslog = NULL, 
 		int ret;
 
 		if ((ret = StealthReadFile(file, buf, CHUNKSIZE, offset, &bytesread, &bytesleft, filesize)) != 0) {
-			if(SparseSkip && strcmp(filepath, journalpath) == 0){
+			if(SparseSkip &&  strlen(filepath) > 3 && strcmp(&(filepath[2]), journalpath) == 0){
 				filesize -= offset;
 				skipclusters = 0;
 				file->data = (CAttrBase*)file->fileRecord->FindNextStream("$J", atrnum);


### PR DESCRIPTION
調査対象でUsersフォルダがシステムドライブとは異なるドライブに存在するケースがあり、レジストリなどが取得できなかったため、そのようなケースに対応させてみました。
また、コマンドラインから実行した際、カレントディレクトリが他の場所となっていると正常に動作しない部分がありましたので、カレントディレクトリを移動してから処理を開始する仕様に変更してみました。

処理の流れを正しく理解できていない部分もあるかもしれませんので、参考としていただき、次期バージョンでUsersフォルダが他のドライブに存在する場合でも動作するように仕様を変更していただければ幸いです。

主な仕様変更点は次のとおりです。
- カレントディレクトリをEXEと同一ディレクトリに設定しないと正常に動作しない
  -> カレントディレクトリをEXEが存在するディレクトリに変更してから実行するように修正
  修正点
  - cdi-collector.exeが存在するディレクトリをGetModuleFileNameで取得
  - 当該ディレクトリをカレントディレクトリに変更してから処理開始

- Userディレクトリがシステムドライブと異なる場合を想定していない
  -> Userディレクトリがシステムドライブと異なる場合に対応
  修正点  
  - Users配下のデータを読み込むドライブをGetProfilesDirectoryで取得するように変更
  - システムドライブとUsersのドライブが異なる場合、両ドライブのMFT&UsnJrnlを取得するように変更
  - StealthGetFile内のUsnJrnlかそれ以外かを判定する条件をドライブ名を無視する仕様に変更
